### PR TITLE
Adding static classnames to image and symbol plugins

### DIFF
--- a/packages/image/src/Image.tsx
+++ b/packages/image/src/Image.tsx
@@ -101,13 +101,17 @@ export default React.forwardRef<HTMLImageElement, ImageProps>(
       }
 
       return (
-        <div style={style} className={defaultTheme.resizeHandle} ref={ref} />
+        <div
+          style={style}
+          className={'GeekieImage-ResizeHandle' && defaultTheme.resizeHandle}
+          ref={ref}
+        />
       );
     };
 
     return (
       <div
-        className={defaultTheme.imageContainer}
+        className={'GeekieImage-ImageContainer' && defaultTheme.imageContainer}
         style={{ height }}
         ref={containerRef}
         onClick={() => setIsFocus(true)}
@@ -144,7 +148,7 @@ export default React.forwardRef<HTMLImageElement, ImageProps>(
               }
               role="presentation"
               draggable="false"
-              className={defaultTheme.image}
+              className={'GeekieImage-Image' && defaultTheme.image}
             />
           </div>
         </Resizable>

--- a/packages/image/src/Image.tsx
+++ b/packages/image/src/Image.tsx
@@ -103,7 +103,7 @@ export default React.forwardRef<HTMLImageElement, ImageProps>(
       return (
         <div
           style={style}
-          className={'GeekieImage-ResizeHandle' && defaultTheme.resizeHandle}
+          className={`GeekieImage-ResizeHandle ${defaultTheme.resizeHandle}`}
           ref={ref}
         />
       );
@@ -111,7 +111,7 @@ export default React.forwardRef<HTMLImageElement, ImageProps>(
 
     return (
       <div
-        className={'GeekieImage-ImageContainer' && defaultTheme.imageContainer}
+        className={`GeekieImage-ImageContainer ${defaultTheme.imageContainer}`}
         style={{ height }}
         ref={containerRef}
         onClick={() => setIsFocus(true)}
@@ -148,7 +148,7 @@ export default React.forwardRef<HTMLImageElement, ImageProps>(
               }
               role="presentation"
               draggable="false"
-              className={'GeekieImage-Image' && defaultTheme.image}
+              className={`GeekieImage-Image ${defaultTheme.image}`}
             />
           </div>
         </Resizable>

--- a/packages/image/src/SelectImageControl.tsx
+++ b/packages/image/src/SelectImageControl.tsx
@@ -121,35 +121,23 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
 
   const renderFileDropPanel: () => React.ReactElement = () => (
     <div
-      className={
-        'GeekieImage-SelectImageControlPanel' &&
-        defaultTheme.selectImageControlPanel
-      }
+      className={`GeekieImage-SelectImageControlPanel ${defaultTheme.selectImageControlPanel}`}
     >
       <div
-        className={
-          'GeekieImage-SelectImageControlPanel__title' &&
-          defaultTheme.selectImageControlPanelTitle
-        }
+        className={`GeekieImage-SelectImageControlPanel__title' ${defaultTheme.selectImageControlPanelTitle}`}
       >
         <span
-          className={
-            'GeekieImage-SelectImageControlPanel__title__label' &&
-            defaultTheme.selectImageControlPanelTitleLabel
-          }
+          className={`GeekieImage-SelectImageControlPanel__title__label ${defaultTheme.selectImageControlPanelTitleLabel}`}
         >
           Carregar arquivo
         </span>
         <span
-          className={
-            'GeekieImage-SelectImageControlPanel__title__border' &&
-            defaultTheme.selectImageControlPanelTitleBorder
-          }
+          className={`GeekieImage-SelectImageControlPanel__title__border ${defaultTheme.selectImageControlPanelTitleBorder}`}
         />
       </div>
 
       <div
-        className={'GeekieImage-DropFileZone' && defaultTheme.dropFileZone}
+        className={`GeekieImage-DropFileZone ${defaultTheme.dropFileZone}`}
         onClick={() => {
           if (refImageInput.current) {
             refImageInput.current.click();
@@ -158,26 +146,17 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
         {...bond}
       >
         <div
-          className={
-            'GeekieImage-DropFileZone__content' &&
-            defaultTheme.dropFileZoneContent
-          }
+          className={`GeekieImage-DropFileZone__content ${defaultTheme.dropFileZoneContent}`}
         >
           {!candidateImage ? (
             <div
-              className={
-                'GeekieImage-DropFileZone__placeholder' &&
-                defaultTheme.dropFileZonePlaceholder
-              }
+              className={`GeekieImage-DropFileZone__placeholder ${defaultTheme.dropFileZonePlaceholder}`}
             >
               Arraste uma imagem aqui ou clique para carregar
             </div>
           ) : (
             <img
-              className={
-                'GeekieImage-DropFileZone__image' &&
-                defaultTheme.dropFileZoneImage
-              }
+              className={`GeekieImage-DropFileZone__image ${defaultTheme.dropFileZoneImage}`}
               src={candidateImage}
             />
           )}
@@ -186,7 +165,7 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
 
       {errorMessage ? (
         <div
-          className={'GeekieImage-ErrorMessage' && defaultTheme.errorMessage}
+          className={`GeekieImage-ErrorMessage ${defaultTheme.errorMessage}`}
         >
           <svg
             width="12"
@@ -209,10 +188,7 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
       ) : null}
 
       <div
-        className={
-          'GeekieImage-SelectImageButtonGroup' &&
-          defaultTheme.selectImageButtonGroup
-        }
+        className={`GeekieImage-SelectImageButtonGroup ${defaultTheme.selectImageButtonGroup}`}
       >
         <div
           className={`GeekieImage-SelectImageButton ${
@@ -229,9 +205,7 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
           Ok
         </div>
         <div
-          className={
-            'GeekieImage-SelectImageButton' && defaultTheme.selectImageButton
-          }
+          className={`GeekieImage-SelectImageButton ${defaultTheme.selectImageButton}`}
           onClick={() => {
             handleCancel();
           }}
@@ -244,10 +218,7 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
 
   return (
     <span
-      className={
-        'GeekieImage-SelectImageControlContainer' &&
-        defaultTheme.selectImageControlContainer
-      }
+      className={`GeekieImage-SelectImageControlContainer ${defaultTheme.selectImageControlContainer}`}
       ref={panelRef}
     >
       <button

--- a/packages/image/src/SelectImageControl.tsx
+++ b/packages/image/src/SelectImageControl.tsx
@@ -120,16 +120,36 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
   });
 
   const renderFileDropPanel: () => React.ReactElement = () => (
-    <div className={defaultTheme.selectImageControlPanel}>
-      <div className={defaultTheme.selectImageControlPanelTitle}>
-        <span className={defaultTheme.selectImageControlPanelTitleLabel}>
+    <div
+      className={
+        'GeekieImage-SelectImageControlPanel' &&
+        defaultTheme.selectImageControlPanel
+      }
+    >
+      <div
+        className={
+          'GeekieImage-SelectImageControlPanel__title' &&
+          defaultTheme.selectImageControlPanelTitle
+        }
+      >
+        <span
+          className={
+            'GeekieImage-SelectImageControlPanel__title__label' &&
+            defaultTheme.selectImageControlPanelTitleLabel
+          }
+        >
           Carregar arquivo
         </span>
-        <span className={defaultTheme.selectImageControlPanelTitleBorder} />
+        <span
+          className={
+            'GeekieImage-SelectImageControlPanel__title__border' &&
+            defaultTheme.selectImageControlPanelTitleBorder
+          }
+        />
       </div>
 
       <div
-        className={defaultTheme.dropFileZone}
+        className={'GeekieImage-DropFileZone' && defaultTheme.dropFileZone}
         onClick={() => {
           if (refImageInput.current) {
             refImageInput.current.click();
@@ -137,14 +157,27 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
         }}
         {...bond}
       >
-        <div className={defaultTheme.dropFileZoneContent}>
+        <div
+          className={
+            'GeekieImage-DropFileZone__content' &&
+            defaultTheme.dropFileZoneContent
+          }
+        >
           {!candidateImage ? (
-            <div className={defaultTheme.dropFileZonePlaceholder}>
+            <div
+              className={
+                'GeekieImage-DropFileZone__placeholder' &&
+                defaultTheme.dropFileZonePlaceholder
+              }
+            >
               Arraste uma imagem aqui ou clique para carregar
             </div>
           ) : (
             <img
-              className={defaultTheme.dropFileZoneImage}
+              className={
+                'GeekieImage-DropFileZone__image' &&
+                defaultTheme.dropFileZoneImage
+              }
               src={candidateImage}
             />
           )}
@@ -152,7 +185,9 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
       </div>
 
       {errorMessage ? (
-        <div className={defaultTheme.errorMessage}>
+        <div
+          className={'GeekieImage-ErrorMessage' && defaultTheme.errorMessage}
+        >
           <svg
             width="12"
             height="10"
@@ -173,10 +208,19 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
         </div>
       ) : null}
 
-      <div className={defaultTheme.selectImageButtonGroup}>
+      <div
+        className={
+          'GeekieImage-SelectImageButtonGroup' &&
+          defaultTheme.selectImageButtonGroup
+        }
+      >
         <div
-          className={`${defaultTheme.selectImageButton}${
-            !candidateImage ? ` ${defaultTheme.selectImageButtonDisabled}` : ''
+          className={`GeekieImage-SelectImageButton ${
+            defaultTheme.selectImageButton
+          } ${
+            !candidateImage
+              ? `GeekieImage-SelectImageButton--disabled ${defaultTheme.selectImageButtonDisabled}`
+              : ''
           }`}
           onClick={() => {
             handleSubmit();
@@ -185,7 +229,9 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
           Ok
         </div>
         <div
-          className={defaultTheme.selectImageButton}
+          className={
+            'GeekieImage-SelectImageButton' && defaultTheme.selectImageButton
+          }
           onClick={() => {
             handleCancel();
           }}
@@ -197,14 +243,23 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
   );
 
   return (
-    <span className={defaultTheme.selectImageControlContainer} ref={panelRef}>
-      <button className="Draftail-ToolbarButton">
+    <span
+      className={
+        'GeekieImage-SelectImageControlContainer' &&
+        defaultTheme.selectImageControlContainer
+      }
+      ref={panelRef}
+    >
+      <button
+        className={`Draftail-ToolbarButton ${
+          showFileDropPanel ? 'Draftail-ToolbarButton--active' : ''
+        }`}
+        onClick={() => {
+          setShowFileDropPanel(!showFileDropPanel);
+        }}
+      >
         <span className="Draftail-ToolbarButton__label">
-          <SelectImageIcon
-            onClick={() => {
-              setShowFileDropPanel(!showFileDropPanel);
-            }}
-          />
+          <SelectImageIcon />
         </span>
       </button>
 

--- a/packages/symbol/src/AddSymbolControl.tsx
+++ b/packages/symbol/src/AddSymbolControl.tsx
@@ -39,31 +39,55 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
 
   const renderSymbolPanel: () => React.ReactElement = () => (
     <Draggable>
-      <div className={defaultTheme.addSymbolControlPanel}>
-        <div className={defaultTheme.addSymbolControlPanelTitle}>
-          <span className={defaultTheme.addSymbolControlPanelTitleLabel}>
+      <div
+        className={
+          'GeekieSymbol-AddSymbolControlPanel' &&
+          defaultTheme.addSymbolControlPanel
+        }
+      >
+        <div
+          className={
+            'GeekieSymbol-AddSymbolControlPanel__title' &&
+            defaultTheme.addSymbolControlPanelTitle
+          }
+        >
+          <span
+            className={
+              'GeekieSymbol-AddSymbolControlPanel__title__label' &&
+              defaultTheme.addSymbolControlPanelTitleLabel
+            }
+          >
             Selecione um caractere especial
           </span>
-          <span className={defaultTheme.addSymbolControlPanelTitleBorder} />
+          <span
+            className={
+              'GeekieSymbol-AddSymbolControlPanel__title__border' &&
+              defaultTheme.addSymbolControlPanelTitleBorder
+            }
+          />
         </div>
-
-        <CloseIcon className={defaultTheme.closeIcon} onClick={handleCancel} />
+        <CloseIcon
+          className={'GeekieSymbol-CloseIcon' && defaultTheme.closeIcon}
+          onClick={handleCancel}
+        />
 
         <Dropdown
-          className={defaultTheme.addSymbolDropdown}
+          className={
+            'GeekieSymbol-AddSymbolDropdown' && defaultTheme.addSymbolDropdown
+          }
           options={catetoriesOptions}
           onChange={(option) => setCurrentCategory(option.value)}
           value={currentCategory}
         />
 
         <div
-          className={defaultTheme.symbolGrids}
+          className={'GeekieSymbol-SymbolGrids' && defaultTheme.symbolGrids}
           style={currentSymbols.length <= 63 ? { overflowY: 'hidden' } : {}}
         >
           {currentSymbols.map((symbol: string) => (
             <div
               key={symbol}
-              className={defaultTheme.symbolGrid}
+              className={'GeekieSymbol-SymbolGrid' && defaultTheme.symbolGrid}
               onClick={() => {
                 handleInsertSymbol(symbol);
               }}
@@ -74,7 +98,7 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
         </div>
 
         <div
-          className={defaultTheme.closeButton}
+          className={'GeekieSymbol-CloseButton' && defaultTheme.closeButton}
           onClick={() => {
             handleCancel();
           }}
@@ -86,15 +110,22 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
   );
 
   return (
-    <span className={defaultTheme.addSymbolControlContainer}>
-      <button className="Draftail-ToolbarButton">
+    <span
+      className={
+        'GeekieSymbol-AddSymbolControlContainer' &&
+        defaultTheme.addSymbolControlContainer
+      }
+    >
+      <button
+        className={`Draftail-ToolbarButton ${
+          showSymbolPanel ? 'Draftail-ToolbarButton--active' : ''
+        }`}
+        onClick={() => {
+          setShowSymbolPanel(!showSymbolPanel);
+        }}
+      >
         <span className="Draftail-ToolbarButton__label">
-          <AddSymbolIcon
-            style={{ width: '12px', height: '12px' }}
-            onClick={() => {
-              setShowSymbolPanel(!showSymbolPanel);
-            }}
-          />
+          <AddSymbolIcon style={{ width: '12px', height: '12px' }} />
         </span>
       </button>
 

--- a/packages/symbol/src/AddSymbolControl.tsx
+++ b/packages/symbol/src/AddSymbolControl.tsx
@@ -40,54 +40,40 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
   const renderSymbolPanel: () => React.ReactElement = () => (
     <Draggable>
       <div
-        className={
-          'GeekieSymbol-AddSymbolControlPanel' &&
-          defaultTheme.addSymbolControlPanel
-        }
+        className={`GeekieSymbol-AddSymbolControlPanel ${defaultTheme.addSymbolControlPanel}`}
       >
         <div
-          className={
-            'GeekieSymbol-AddSymbolControlPanel__title' &&
-            defaultTheme.addSymbolControlPanelTitle
-          }
+          className={`GeekieSymbol-AddSymbolControlPanel__title ${defaultTheme.addSymbolControlPanelTitle}`}
         >
           <span
-            className={
-              'GeekieSymbol-AddSymbolControlPanel__title__label' &&
-              defaultTheme.addSymbolControlPanelTitleLabel
-            }
+            className={`GeekieSymbol-AddSymbolControlPanel__title__label ${defaultTheme.addSymbolControlPanelTitleLabel}`}
           >
             Selecione um caractere especial
           </span>
           <span
-            className={
-              'GeekieSymbol-AddSymbolControlPanel__title__border' &&
-              defaultTheme.addSymbolControlPanelTitleBorder
-            }
+            className={`GeekieSymbol-AddSymbolControlPanel__title__border ${defaultTheme.addSymbolControlPanelTitleBorder}`}
           />
         </div>
         <CloseIcon
-          className={'GeekieSymbol-CloseIcon' && defaultTheme.closeIcon}
+          className={`GeekieSymbol-CloseIcon ${defaultTheme.closeIcon}`}
           onClick={handleCancel}
         />
 
         <Dropdown
-          className={
-            'GeekieSymbol-AddSymbolDropdown' && defaultTheme.addSymbolDropdown
-          }
+          className={`GeekieSymbol-AddSymbolDropdown ${defaultTheme.addSymbolDropdown}`}
           options={catetoriesOptions}
           onChange={(option) => setCurrentCategory(option.value)}
           value={currentCategory}
         />
 
         <div
-          className={'GeekieSymbol-SymbolGrids' && defaultTheme.symbolGrids}
+          className={`GeekieSymbol-SymbolGrids ${defaultTheme.symbolGrids}`}
           style={currentSymbols.length <= 63 ? { overflowY: 'hidden' } : {}}
         >
           {currentSymbols.map((symbol: string) => (
             <div
               key={symbol}
-              className={'GeekieSymbol-SymbolGrid' && defaultTheme.symbolGrid}
+              className={`GeekieSymbol-SymbolGrid ${defaultTheme.symbolGrid}`}
               onClick={() => {
                 handleInsertSymbol(symbol);
               }}
@@ -98,7 +84,7 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
         </div>
 
         <div
-          className={'GeekieSymbol-CloseButton' && defaultTheme.closeButton}
+          className={`GeekieSymbol-CloseButton ${defaultTheme.closeButton}`}
           onClick={() => {
             handleCancel();
           }}
@@ -111,10 +97,7 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
 
   return (
     <span
-      className={
-        'GeekieSymbol-AddSymbolControlContainer' &&
-        defaultTheme.addSymbolControlContainer
-      }
+      className={`GeekieSymbol-AddSymbolControlContainer ${defaultTheme.addSymbolControlContainer}`}
     >
       <button
         className={`Draftail-ToolbarButton ${


### PR DESCRIPTION
This PR adding static classnames to image and symbol plugins.

## Use-case/Problem

The random generated classnames didn't allow us to correctly customize the image plugin styles. If we used those classnames, our changes would be lost if they were replaced by a new build.

## Implementation

I've added static classnames to geekie image and geekie symbol, following the draftail pattern, to allow better styling customization. Also updated the toolbar button click handling, to add the "--active" classname.


