### PR TITLE
Paste images

### DIFF
--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geekie/geekie-image",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/image/src/index.tsx
+++ b/packages/image/src/index.tsx
@@ -25,6 +25,8 @@ export type ImageEditorPlugin = EditorPlugin & {
   };
 };
 
+const ACCEPTED_MIMES = ['image/png', 'image/jpeg', 'image/gif'];
+
 const createSetResizeData =
   (
     contentBlock: ContentBlock,
@@ -91,6 +93,22 @@ export default (config: ImagePluginConfig = {}): ImageEditorPlugin => {
       }
 
       return null;
+    },
+    handlePastedFiles(e, editor) {
+      const editorState = editor.getEditorState();
+      if (e.length !== 1) return;
+      const image = e[0];
+      if (ACCEPTED_MIMES.indexOf(image.type) < 0) return;
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const url = event.target.result;
+        const newEditorState = addImage(editorState, url, {
+          width: 500,
+          height: 500
+        });
+        editor.setEditorState(newEditorState);
+      };
+      reader.readAsDataURL(image);
     },
     addImage,
     control,

--- a/packages/image/src/index.tsx
+++ b/packages/image/src/index.tsx
@@ -1,11 +1,12 @@
 import React, { ComponentType, ReactElement } from 'react';
 import { ContentBlock, EditorState } from 'draft-js';
-import { EditorPlugin } from '@draft-js-plugins/editor';
+import { EditorPlugin } from '../../editor/src';
 import addImage, { IMAGE_ENTITY_TYPE } from './modifiers/addImage';
 import ImageComponent, { ImageProps } from './Image';
 import { control, SelectImageControl } from './SelectImageControl';
 import { defaultTheme } from './theme';
-import { setFileLimitation } from './register';
+import { getUploadImage, setFileLimitation } from './register';
+import { getAcceptableSize, getHeightAndWidthFromDataUrl, isValidImageSize, isValidImageType } from './utils';
 
 export { registerUploadImageTask, setFileLimitation } from './register';
 
@@ -24,8 +25,6 @@ export type ImageEditorPlugin = EditorPlugin & {
     type: string;
   };
 };
-
-const ACCEPTED_MIMES = ['image/png', 'image/jpeg', 'image/gif'];
 
 const createSetResizeData =
   (
@@ -69,52 +68,37 @@ export default (config: ImagePluginConfig = {}): ImageEditorPlugin => {
 
   return {
     blockRendererFn: (block, { getEditorState, setEditorState }) => {
-      if (block.getType() === 'atomic') {
-        const contentState = getEditorState().getCurrentContent();
-        const entity = block.getEntityAt(0);
-        if (!entity) return null;
-        const type = contentState.getEntity(entity).getType();
-        const resizeData = contentState.getEntity(entity).getData();
-
-        if (type === IMAGE_ENTITY_TYPE) {
-          return {
-            component: ThemedImage,
-            editable: false,
-            props: {
-              resizeData,
-              setResizeData: createSetResizeData(block, {
-                getEditorState,
-                setEditorState,
-              }),
-            },
-          };
-        }
-        return null;
-      }
-
-      return null;
-    },
-    handlePastedFiles(e, editor) {
-      const editorState = editor.getEditorState();
-      if (e.length !== 1) return;
-      const image = e[0];
-      if (ACCEPTED_MIMES.indexOf(image.type) < 0) return;
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        const url = event.target.result;
-        const newEditorState = addImage(editorState, url, {
-          width: 500,
-          height: 500
-        });
-        editor.setEditorState(newEditorState);
+      if (block.getType() !== 'atomic') return null;
+      const contentState = getEditorState().getCurrentContent();
+      const entity = block.getEntityAt(0);
+      if (!entity) return null;
+      const type = contentState.getEntity(entity).getType();
+      const resizeData = contentState.getEntity(entity).getData();
+      if (type !== IMAGE_ENTITY_TYPE) return null;
+      return {
+        component: ThemedImage,
+        editable: false,
+        props: {
+          resizeData,
+          setResizeData: createSetResizeData(block, {
+            getEditorState,
+            setEditorState,
+          }),
+        },
       };
-      reader.readAsDataURL(image);
+    },
+    handlePastedFiles: (files: File[], { getEditorState, setEditorState }) => {
+      if (!files.length || !isValidImageType(files[0]) || !isValidImageSize(files[0])) return 'handled';
+      getUploadImage()(files[0]).then(async (dataURL) => {
+        const originalSize = await getHeightAndWidthFromDataUrl(dataURL);
+        const acceptableSize = getAcceptableSize(originalSize);
+        setEditorState(addImage(getEditorState(), dataURL, acceptableSize));
+      })
+      return 'handled';
     },
     addImage,
     control,
-    entityType: {
-      type: IMAGE_ENTITY_TYPE,
-    },
+    entityType: { type: IMAGE_ENTITY_TYPE, }
   };
 };
 

--- a/packages/image/src/register.ts
+++ b/packages/image/src/register.ts
@@ -20,7 +20,7 @@ export const registerUploadImageTask: (
 
 export const pluginConfig = {
   // file size limitation in unit MB
-  fileLimitation: 100,
+  fileLimitation: 3,
 };
 
 export const setFileLimitation = (limitation: number): void => {

--- a/packages/image/src/utils.ts
+++ b/packages/image/src/utils.ts
@@ -1,4 +1,4 @@
-import { pluginConfig } from "./register";
+import { pluginConfig } from './register';
 
 const ACCEPTED_MIMES = ['image/png', 'image/jpeg', 'image/gif'];
 const MAX_IMAGE_DIMENSION_PX = 500;
@@ -8,18 +8,27 @@ type Size = {
   height: number;
 };
 
-export const getAcceptableSize = ({width, height}: Size): Size => {
+type GetAcceptableSizeProps = Size & {
+  maxDimension?: number;
+};
+
+export const getAcceptableSize = ({
+  width,
+  height,
+  maxDimension,
+}: GetAcceptableSizeProps): Size => {
+  const max = maxDimension || MAX_IMAGE_DIMENSION_PX;
   let limitWidth = width;
   let limitHeight = height;
   const ratio = width / height;
   if (ratio > 1) {
-    if (width > MAX_IMAGE_DIMENSION_PX) {
-      limitWidth = MAX_IMAGE_DIMENSION_PX;
+    if (width > max) {
+      limitWidth = max;
       limitHeight = limitWidth / ratio;
     }
   } else {
-    if (height > MAX_IMAGE_DIMENSION_PX) {
-      limitHeight = MAX_IMAGE_DIMENSION_PX;
+    if (height > max) {
+      limitHeight = max;
       limitWidth = limitHeight * ratio;
     }
   }
@@ -38,6 +47,8 @@ export const getHeightAndWidthFromDataUrl = (dataURL: string): Promise<Size> =>
     img.src = dataURL;
   });
 
-export const isValidImageType = (file: File): boolean => ACCEPTED_MIMES.includes(file.type);
+export const isValidImageType = (file: File): boolean =>
+  ACCEPTED_MIMES.includes(file.type);
 
-export const isValidImageSize = (file: File): boolean => file.size <= pluginConfig.fileLimitation * 1024 * 1024;
+export const isValidImageSize = (file: File): boolean =>
+  file.size <= pluginConfig.fileLimitation * 1024 * 1024;

--- a/packages/image/src/utils.ts
+++ b/packages/image/src/utils.ts
@@ -1,0 +1,43 @@
+import { pluginConfig } from "./register";
+
+const ACCEPTED_MIMES = ['image/png', 'image/jpeg', 'image/gif'];
+const MAX_IMAGE_DIMENSION_PX = 500;
+
+type Size = {
+  width: number;
+  height: number;
+};
+
+export const getAcceptableSize = ({width, height}: Size): Size => {
+  let limitWidth = width;
+  let limitHeight = height;
+  const ratio = width / height;
+  if (ratio > 1) {
+    if (width > MAX_IMAGE_DIMENSION_PX) {
+      limitWidth = MAX_IMAGE_DIMENSION_PX;
+      limitHeight = limitWidth / ratio;
+    }
+  } else {
+    if (height > MAX_IMAGE_DIMENSION_PX) {
+      limitHeight = MAX_IMAGE_DIMENSION_PX;
+      limitWidth = limitHeight * ratio;
+    }
+  }
+  return { width: limitWidth, height: limitHeight };
+};
+
+export const getHeightAndWidthFromDataUrl = (dataURL: string): Promise<Size> =>
+  new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      resolve({
+        height: img.height,
+        width: img.width,
+      });
+    };
+    img.src = dataURL;
+  });
+
+export const isValidImageType = (file: File): boolean => ACCEPTED_MIMES.includes(file.type);
+
+export const isValidImageSize = (file: File): boolean => file.size <= pluginConfig.fileLimitation * 1024 * 1024;

--- a/stories/add-symbols/src/SymbolEditor.tsx
+++ b/stories/add-symbols/src/SymbolEditor.tsx
@@ -1,14 +1,17 @@
 import React, { ReactElement } from 'react';
 import { DraftailEditor as Editor, INLINE_STYLE } from 'draftail';
+import 'draftail/dist/draftail.css';
 import createSymbolPlugin, {
   registerInsertSymbolCallback,
-} from '@draft-js-plugins/symbol';
-import 'draftail/dist/draftail.css';
+} from '../../../packages/symbol/src';
 
 const symbolPlugin = createSymbolPlugin();
 const plugins = [symbolPlugin];
 
-registerInsertSymbolCallback((symbol) => console.log(symbol));
+registerInsertSymbolCallback((symbol) => {
+  // eslint-disable-next-line no-console
+  console.log(symbol);
+});
 
 const SimpleImageEditor = (): ReactElement => (
   <div>

--- a/stories/displaying-images/src/SimpleImageEditor.tsx
+++ b/stories/displaying-images/src/SimpleImageEditor.tsx
@@ -43,19 +43,19 @@ const SimpleImageEditor = (): ReactElement => {
   const [editorState, setEditorState] = useState(
     EditorState.createWithContent(contentState)
   );
+  const [htmlOutput, setHtmlOutput] = useState('');
 
   return (
     <div>
+      <pre>{htmlOutput}</pre>
       <Editor
-        readOnly
         topTool
         editorState={editorState}
         controls={[imagePlugin.control]}
         // eslint-disable-next-line no-shadow
         onChange={(editorState: EditorState) => {
           setEditorState(editorState);
-          // eslint-disable-next-line no-console
-          console.log('editorState as html: ', convertToHTML(editorState));
+          setHtmlOutput(convertToHTML(editorState));
         }}
         inlineStyles={[
           { type: INLINE_STYLE.BOLD },


### PR DESCRIPTION
Implementa a interface `handlePastedFiles` no plugin de imagens para suportar colar imagens no editor.

É possível validar pelo Storybook através da Story `Editor with Image Plugin`.