### PR TITLE
link plugin style changes

### DIFF
--- a/packages/linkify/src/theme.ts
+++ b/packages/linkify/src/theme.ts
@@ -34,12 +34,19 @@ export const defaultTheme: LinkifyPluginTheme = {
     width: 244px;
     height: 32px;
     margin-left: 16px;
+    padding: 0 4px;
+    &:hover {
+      border: 1px solid #81a3ef;
+    }
+    &:last-of-type {
+      margin-bottom: 10px;
+    }
   `,
 
   styleLabel: css`
     display: block;
-    font-weight: 700;
-    font-family: Lato, Arial;
+    font-weight: regular;
+    font-family: sans-serif;
     font-size: 14px;
     line-height: 17px;
     margin-top: 15px;
@@ -50,7 +57,7 @@ export const defaultTheme: LinkifyPluginTheme = {
     pointer-events: all;
     border: 1px solid #f1f1f1;
     box-shadow: 2px 3px 8px rgba(0, 0, 0, 0.3);
-    font-family: Lato, Arial;
+    font-family: sans-serif;
     width: 280px;
     text-align: center;
     background-color: #ffffff;
@@ -61,7 +68,7 @@ export const defaultTheme: LinkifyPluginTheme = {
   `,
   styleLinkSpan: css`
     display: inline-block;
-    color: #0f6dff;
+    color: #0b43bf;
     text-decoration: underline;
     position: relative;
     &:hover {
@@ -85,6 +92,7 @@ export const defaultTheme: LinkifyPluginTheme = {
     border: 1px solid #f1f1f1;
     box-shadow: 2px 3px 8px rgba(0, 0, 0, 0.1);
     border-radius: 2px;
+    padding: 0 18px;
     top: 25px;
     text-align: center;
     z-index: 99;
@@ -92,7 +100,7 @@ export const defaultTheme: LinkifyPluginTheme = {
   `,
   styleLinkTooltip: css`
     text-decoration: none;
-    font-family: Lato, Arial;
+    font-family: sans-serif;
     font-style: normal;
     font-weight: bold;
     line-height: 40px;
@@ -101,8 +109,6 @@ export const defaultTheme: LinkifyPluginTheme = {
     text-overflow: ellipsis;
     white-space: nowrap;
     display: inline-block;
-    padding-left: 8px;
-    padding-right: 8px;
     vertical-align: top;
     &:hover {
       cursor: pointer;
@@ -110,22 +116,24 @@ export const defaultTheme: LinkifyPluginTheme = {
   `,
   styleLinkUrl: css`
     font-size: 14px;
-    color: #0f6dff;
+    margin-right: 9px;
+    color: #0b43bf;
     &:hover {
       text-decoration: underline;
     }
   `,
   styleLinkTooltipIcon: css`
-    margin-left: 18px;
     margin-right: 12px;
   `,
   styleLinkTooltipText: css`
     font-size: 13px;
-    padding-right: 12px;
-    padding-left: 12px;
+    margin: 0 9px
     color: #111112;
     &:hover {
       color: #0b43bf;
+    }
+    &:last-of-type{
+      margin: 0 0 0 9px;
     }
   `,
 };


### PR DESCRIPTION
**Modal (Texto/Link)**

- Mudar fonte para Lato (feito no SGLeaner)
- Mudar de Bold para Regular os textos ‘Texto’ e ‘Link’
- Mudar cor da borda preta do campo de texto quando está selecionada para azul (81A3EF) e espessura igual ao quando ela fica cinza.
- Aumentar espaçamento entre a lateral do campo de texto esquerda com o primeiro caractere do texto (espaçamento total de 4 px)
- Aumentar espaçamento entre campo de texto do Link e botões (espaçamento total de 20 px)


**Editar/Remover**

- Mudar fonte para Lato (feito no SGLeaner)
- Mudar cor do link para esse azul (0b43bf) - tanto no texto dentro do editor, quanto no link
- Aumentar espaçamento entre Remover e a borda lateral direita da caixa branca (espaçamento total de 18 px)
- Diminuir espaçamento entre borda lateral esquerda da caixa branca e o ícone do link (espaçamento total de 18 px)