### PR TITLE
fix: sets editor to read-only mode while resizing images

### DIFF
--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geekie/geekie-image",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/image/src/Image.tsx
+++ b/packages/image/src/Image.tsx
@@ -3,6 +3,7 @@ import React, {
   CSSProperties,
   ImgHTMLAttributes,
   ReactElement,
+  useEffect,
   useRef,
   useState,
 } from 'react';
@@ -26,6 +27,8 @@ export interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   blockProps: {
     resizeData?: ResizeData;
     setResizeData: (data: ResizeData) => void;
+    onStartEdit: () => void;
+    onFinishEdit: () => void;
   };
   customStyleMap: unknown;
   customStyleFn: unknown;
@@ -43,7 +46,12 @@ export default React.forwardRef<HTMLImageElement, ImageProps>(
     const { block, ...otherProps } = props;
     // leveraging destructuring to omit certain properties from props
     const {
-      blockProps: { setResizeData, resizeData = { width: 500, height: 500 } },
+      blockProps: {
+        setResizeData,
+        resizeData = { width: 500, height: 500 },
+        onStartEdit,
+        onFinishEdit,
+      },
       customStyleMap, // eslint-disable-line @typescript-eslint/no-unused-vars
       customStyleFn, // eslint-disable-line @typescript-eslint/no-unused-vars
       decorator, // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -63,10 +71,13 @@ export default React.forwardRef<HTMLImageElement, ImageProps>(
 
     const [isFocus, setIsFocus] = useState(false);
 
+    useEffect(() => onStartEdit(), [isFocus]);
+
     const containerRef = useRef(null);
     useClickAway(containerRef, (event) => {
       event.stopPropagation();
       setIsFocus(false);
+      onFinishEdit();
     });
 
     // eslint-disable-next-line no-shadow

--- a/packages/image/src/SelectImageControl.tsx
+++ b/packages/image/src/SelectImageControl.tsx
@@ -165,17 +165,13 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
               ? `GeekieImage-SelectImageButton--disabled ${defaultTheme.selectImageButtonDisabled}`
               : ''
           }`}
-          onClick={() => {
-            handleSubmit();
-          }}
+          onClick={handleSubmit}
         >
           Ok
         </div>
         <div
           className={`GeekieImage-SelectImageButton ${defaultTheme.selectImageButton}`}
-          onClick={() => {
-            handleCancel();
-          }}
+          onClick={handleCancel}
         >
           Cancelar
         </div>
@@ -208,7 +204,7 @@ export const control: React.ComponentType<DraftToolbarControlProps> = (
       <input
         type="file"
         style={{ display: 'none' }}
-        accept="image/*"
+        accept=".jpg,.gif,.jpeg,.png"
         ref={refImageInput}
         onChange={handleImageChange}
       />

--- a/packages/image/src/index.tsx
+++ b/packages/image/src/index.tsx
@@ -71,7 +71,10 @@ export default (config: ImagePluginConfig = {}): ImageEditorPlugin => {
   );
 
   return {
-    blockRendererFn: (block, { getEditorState, setEditorState }) => {
+    blockRendererFn: (
+      block,
+      { getEditorState, setEditorState, setReadOnly }
+    ) => {
       if (block.getType() !== 'atomic') return null;
       const contentState = getEditorState().getCurrentContent();
       const entity = block.getEntityAt(0);
@@ -84,10 +87,21 @@ export default (config: ImagePluginConfig = {}): ImageEditorPlugin => {
         editable: false,
         props: {
           resizeData,
+          onStartEdit: () => setReadOnly(true),
+          onFinishEdit: () => {
+            setReadOnly(false);
+            setEditorState(
+              EditorState.forceSelection(
+                getEditorState(),
+                getEditorState().getSelection()
+              )
+            );
+          },
           setResizeData: createSetResizeData(block, {
             getEditorState,
             setEditorState,
           }),
+          getEditorState,
         },
       };
     },

--- a/packages/image/src/index.tsx
+++ b/packages/image/src/index.tsx
@@ -101,7 +101,6 @@ export default (config: ImagePluginConfig = {}): ImageEditorPlugin => {
             getEditorState,
             setEditorState,
           }),
-          getEditorState,
         },
       };
     },

--- a/packages/image/src/utils.ts
+++ b/packages/image/src/utils.ts
@@ -1,14 +1,14 @@
 import { pluginConfig } from './register';
 
-const ACCEPTED_MIMES = ['image/png', 'image/jpeg', 'image/gif'];
+const ACCEPTED_MIMES = ['image/gif', 'image/jpeg', 'image/jpg', 'image/png'];
 const MAX_IMAGE_DIMENSION_PX = 500;
 
-type Size = {
+type Dimensions = {
   width: number;
   height: number;
 };
 
-type GetAcceptableSizeProps = Size & {
+type GetAcceptableSizeProps = Dimensions & {
   maxDimension?: number;
 };
 
@@ -16,7 +16,7 @@ export const getAcceptableSize = ({
   width,
   height,
   maxDimension,
-}: GetAcceptableSizeProps): Size => {
+}: GetAcceptableSizeProps): Dimensions => {
   const max = maxDimension || MAX_IMAGE_DIMENSION_PX;
   let limitWidth = width;
   let limitHeight = height;
@@ -35,7 +35,9 @@ export const getAcceptableSize = ({
   return { width: limitWidth, height: limitHeight };
 };
 
-export const getHeightAndWidthFromDataUrl = (dataURL: string): Promise<Size> =>
+export const getHeightAndWidthFromDataUrl = (
+  dataURL: string
+): Promise<Dimensions> =>
   new Promise((resolve) => {
     const img = new Image();
     img.onload = () => {


### PR DESCRIPTION
Issue: When selecting an image and pressing the `backspace` key, the image block is deleted but not the associated 
entity, causing the image to reappear when translating entities to html.

This PR attemps to circumvent this problem by setting the editor to read-only mode while the image is in focus. 