### PR TITLE
fix: stop forcing selection/focus on the editor when clicking away

### DIFF
--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geekie/geekie-image",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/image/src/index.tsx
+++ b/packages/image/src/index.tsx
@@ -88,15 +88,7 @@ export default (config: ImagePluginConfig = {}): ImageEditorPlugin => {
         props: {
           resizeData,
           onStartEdit: () => setReadOnly(true),
-          onFinishEdit: () => {
-            setReadOnly(false);
-            setEditorState(
-              EditorState.forceSelection(
-                getEditorState(),
-                getEditorState().getSelection()
-              )
-            );
-          },
+          onFinishEdit: () => setReadOnly(false),
           setResizeData: createSetResizeData(block, {
             getEditorState,
             setEditorState,


### PR DESCRIPTION
### Issue
Currently if the screen has 2 or more instances of an editor using the Image Plugin, when the user clicks away from an image the cursor focus will move to the latest editor that has added an image.
### Solution
Removes the `Editor.forceSelection` when clicking away (blur event or `useClickAway`).
### How to test
One way to test it is to duplicate the editor instance in the `SimpleImageEditor.tsx` story file (using another `editorState` and `onChange` prop), then using the `Image/Editor with Image Plugin storybook` to add an image to one of the editors and trying to use the inline styles on the other editor, if it works the cursor focus will not jump to the editor that has added the image.