### PR TITLE
fix: enables image removal using backspace and delete, working with undo/redo

### DIFF
--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geekie/geekie-image",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/image/src/Image.tsx
+++ b/packages/image/src/Image.tsx
@@ -27,8 +27,7 @@ export interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   blockProps: {
     resizeData?: ResizeData;
     setResizeData: (data: ResizeData) => void;
-    onStartEdit: () => void;
-    onFinishEdit: () => void;
+    onChangeFocus: (isFocus: boolean) => void;
   };
   customStyleMap: unknown;
   customStyleFn: unknown;
@@ -49,8 +48,7 @@ export default React.forwardRef<HTMLImageElement, ImageProps>(
       blockProps: {
         setResizeData,
         resizeData = { width: 500, height: 500 },
-        onStartEdit,
-        onFinishEdit,
+        onChangeFocus,
       },
       customStyleMap, // eslint-disable-line @typescript-eslint/no-unused-vars
       customStyleFn, // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -71,16 +69,12 @@ export default React.forwardRef<HTMLImageElement, ImageProps>(
 
     const [isFocus, setIsFocus] = useState(false);
 
-    useEffect(() => {
-      if (isFocus) onStartEdit();
-    }, [isFocus]);
+    useEffect(() => onChangeFocus(isFocus), [isFocus]);
 
     const containerRef = useRef(null);
     useClickAway(containerRef, (event) => {
       event.stopPropagation();
-      if (!isFocus) return;
       setIsFocus(false);
-      onFinishEdit();
     });
 
     // eslint-disable-next-line no-shadow

--- a/packages/image/src/index.tsx
+++ b/packages/image/src/index.tsx
@@ -111,11 +111,12 @@ export default (config: ImagePluginConfig = {}): ImageEditorPlugin => {
       });
       return 'handled';
     },
-    keyBindingFn(event, { getEditorState, setEditorState }) {
+    keyBindingFn: (event, { getEditorState, setEditorState }) => {
       if (event.key !== 'Backspace' || !focusedBlock) return undefined;
       const editorState = getEditorState();
       const newEditorState = removeImage(editorState, focusedBlock.getKey());
       setEditorState(newEditorState);
+      focusedBlock = null;
       return 'handled';
     },
     addImage,

--- a/packages/image/src/modifiers/removeImage.ts
+++ b/packages/image/src/modifiers/removeImage.ts
@@ -1,0 +1,47 @@
+import { EditorState, Modifier, SelectionState } from 'draft-js';
+
+export default (editorState: EditorState, blockKey: string): EditorState => {
+  let content = editorState.getCurrentContent();
+  const newSelection = new SelectionState({
+    anchorKey: blockKey,
+    anchorOffset: 0,
+    focusKey: blockKey,
+    focusOffset: 0,
+  });
+
+  const afterKey = content.getKeyAfter(blockKey);
+  const afterBlock = content.getBlockForKey(afterKey);
+  let targetRange;
+
+  // Only if the following block the last with no text then the whole block
+  // should be removed. Otherwise the block should be reduced to an unstyled block
+  // without any characters.
+  if (
+    afterBlock &&
+    afterBlock.getType() === 'unstyled' &&
+    afterBlock.getLength() === 0 &&
+    afterBlock === content.getBlockMap().last()
+  ) {
+    targetRange = new SelectionState({
+      anchorKey: blockKey,
+      anchorOffset: 0,
+      focusKey: afterKey,
+      focusOffset: 0,
+    });
+  } else {
+    targetRange = new SelectionState({
+      anchorKey: blockKey,
+      anchorOffset: 0,
+      focusKey: blockKey,
+      focusOffset: 1,
+    });
+  }
+
+  // change the blocktype and remove the characterList entry with the sticker
+  content = Modifier.setBlockType(content, targetRange, 'unstyled');
+  content = Modifier.removeRange(content, targetRange, 'backward');
+
+  // force to new selection
+  const newState = EditorState.push(editorState, content, 'remove-range');
+  return EditorState.forceSelection(newState, newSelection);
+};

--- a/packages/image/src/modifiers/removeImage.ts
+++ b/packages/image/src/modifiers/removeImage.ts
@@ -13,7 +13,7 @@ export default (editorState: EditorState, blockKey: string): EditorState => {
   const afterBlock = content.getBlockForKey(afterKey);
   let targetRange;
 
-  // Only if the following block the last with no text then the whole block
+  // Only if the following block is the last with no text then the whole block
   // should be removed. Otherwise the block should be reduced to an unstyled block
   // without any characters.
   if (


### PR DESCRIPTION
### Issue

When focusing on an image and hitting backspace or delete the image is not being removed.

### Solution

Implements the expected behavior when using backspace or delete.