### PR TITLE
fix: Keep proportions when resizing

### DIFF
--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geekie/geekie-image",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/image/src/constants.ts
+++ b/packages/image/src/constants.ts
@@ -1,0 +1,12 @@
+export const ACCEPTED_MIMES = [
+  'image/gif',
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+];
+
+export const MAX_IMAGE_INITIAL_DIMENSION_PX = 500;
+
+export const MIN_CONSTRAINT_PX = 50;
+
+export const MAX_CONSTRAINT_PX = 824;

--- a/packages/image/src/transformHTML.ts
+++ b/packages/image/src/transformHTML.ts
@@ -1,3 +1,5 @@
+import { MAX_IMAGE_INITIAL_DIMENSION_PX } from './constants';
+
 type TransformImageEntity = {
   type: string;
   mutability: string;
@@ -37,13 +39,18 @@ export const htmlToImageEntity = (
   node: HTMLImageElement
 ): TransformImageEntity | undefined => {
   if (nodeName === 'img' && node.hasAttribute(imageTypeAttributeLabel)) {
+    const maxImageInitialDimension = MAX_IMAGE_INITIAL_DIMENSION_PX.toString();
     return {
       type: 'GEEKIE_IMAGE',
       mutability: 'IMMUTABLE',
       data: {
         src: node.getAttribute('src') || '',
-        height: parseFloat(getDataAttribute(node, 'height') || '500'),
-        width: parseFloat(getDataAttribute(node, 'width') || '500'),
+        height: parseFloat(
+          getDataAttribute(node, 'height') || maxImageInitialDimension
+        ),
+        width: parseFloat(
+          getDataAttribute(node, 'width') || maxImageInitialDimension
+        ),
       },
     };
   }

--- a/packages/image/src/utils.ts
+++ b/packages/image/src/utils.ts
@@ -1,7 +1,5 @@
+import { ACCEPTED_MIMES, MAX_IMAGE_INITIAL_DIMENSION_PX } from './constants';
 import { pluginConfig } from './register';
-
-const ACCEPTED_MIMES = ['image/gif', 'image/jpeg', 'image/jpg', 'image/png'];
-const MAX_IMAGE_DIMENSION_PX = 500;
 
 type Dimensions = {
   width: number;
@@ -17,7 +15,7 @@ export const getAcceptableSize = ({
   height,
   maxDimension,
 }: GetAcceptableSizeProps): Dimensions => {
-  const max = maxDimension || MAX_IMAGE_DIMENSION_PX;
+  const max = maxDimension || MAX_IMAGE_INITIAL_DIMENSION_PX;
   let limitWidth = width;
   let limitHeight = height;
   const ratio = width / height;

--- a/stories/displaying-images/src/SimpleImageEditor.tsx
+++ b/stories/displaying-images/src/SimpleImageEditor.tsx
@@ -26,7 +26,7 @@ const plugins = [imagePlugin];
 const html = `<p>This is a paragraph!</p>
 <p><strong>This is a bold paragraph!</strong></p>
 <p></p>
-<img src="https://picsum.photos/300/300" data-geekie-image data-width="580.1666660308838" data-height="580.1666660308838" style="height: 580.1666660308838px;width: 580.1666660308838px" />
+<img src="https://picsum.photos/200/400" data-geekie-image data-width="200" data-height="400" style="height: 400px;width: 200px" />
 <p></p>
 <p><em>This is an italic paragraph!</em></p>
 <p><strong>This</strong> <em>one</em> is kind of mixed 😅</p>
@@ -34,7 +34,7 @@ const html = `<p>This is a paragraph!</p>
 `;
 
 // Register how to upload the selected image
-registerUploadImageTask(() => Promise.resolve('https://picsum.photos/300/300'));
+registerUploadImageTask(() => Promise.resolve('https://picsum.photos/500/200'));
 
 const SimpleImageEditor = (): ReactElement => {
   const contentState = ContentState.createFromBlockArray(


### PR DESCRIPTION
### Issue

When resizing up or down an image, if the image proportion/ratio is not 1 (meaning the image is not square shaped) the ratio can change during the resize, which damages the image resolution.

### Solution

The aspect ratio of the image is maintained when resizing.

### How to test

Try resizing both square shaped images and not square shaped and check if the aspect ratio is maintained while the maximum and minimum size constraints are respected.