### PR TITLE
fix: remove readonly when removing katex blocks

### DIFF
--- a/packages/katex/package.json
+++ b/packages/katex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geekie/geekie-katex",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/katex/src/index.tsx
+++ b/packages/katex/src/index.tsx
@@ -68,6 +68,7 @@ export default (): KatexPlugin => {
             blocksInEditingMode.delete(blockKey);
             const editorState = getEditorState();
             const newEditorState = removeKatexBlock(editorState, blockKey);
+            setReadOnly(false);
             setEditorState(newEditorState);
           },
         },


### PR DESCRIPTION
### Issue

When removing a katex block, the editor remains in readonly mode, so the user is not able to continue typing inside the editor.

### Solution

Turn off the readonly mode when removing a katex block.

### How to test

In the storybook `Katex/Katex plugin` compare the issue (main branch) with the solution.