### PR TITLE
fix: removes the latex textarea and adds autofocus when entering editing mode

### DIFF
--- a/packages/katex/package.json
+++ b/packages/katex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geekie/geekie-katex",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "sideEffects": [
     "*.css"
   ],
@@ -38,7 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "katex": "0.16.0",
-    "math-input-web-support": "0.2.4",
+    "math-input-web-support": "0.2.5",
     "mathquill-commonjs": "0.10.3"
   },
   "devDependencies": {

--- a/packages/katex/src/components/KatexBlock.tsx
+++ b/packages/katex/src/components/KatexBlock.tsx
@@ -1,7 +1,7 @@
 import { ContentBlock, EditorState } from 'draft-js';
 import katex from 'katex';
 import MathInput from 'math-input-web-support/dist/components/app';
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import KatexOutput from './KatexOutput';
 
 type KatexInternals = typeof katex & {
@@ -39,6 +39,7 @@ const KatexBlock = (props: Props): JSX.Element => {
   const [isEditing, setIsEditing] = useState(data.isEditing);
   const [isInvalidTex, setIsInvalidTex] = useState(data.isInvalidTex);
   const [value, setValue] = useState(data.value);
+  const mathInput = useRef<{ focus: () => void }>(null);
 
   const callbacks: { [key: string]: () => void } = {};
 
@@ -55,10 +56,6 @@ const KatexBlock = (props: Props): JSX.Element => {
     } finally {
       setValue(inputValue);
     }
-  };
-
-  const onFocus = (): void => {
-    if (callbacks.blur) callbacks.blur();
   };
 
   const startEdit = (): void => {
@@ -96,9 +93,13 @@ const KatexBlock = (props: Props): JSX.Element => {
     margin: '0 3px',
   };
 
+  useEffect(() => {
+    if (!mathInput.current) return;
+    mathInput.current.focus();
+  }, [isEditing]);
+
   const editingForm = (
     <div className="GeekieKatex-EditPanel">
-      <textarea onChange={onValueChange} onFocus={onFocus} value={value} />
       <div className="GeekieKatex-EditPanel-Buttons">
         <button
           style={buttonStyle}
@@ -117,10 +118,10 @@ const KatexBlock = (props: Props): JSX.Element => {
   const display = isEditing ? (
     <MathInput
       callbacks={callbacks}
-      displayMode
       katex={katex}
       onChange={onValueChange}
       value={value}
+      ref={mathInput}
     />
   ) : (
     <KatexOutput onClick={startEdit} value={value} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -9162,10 +9162,10 @@ matched@^5.0.1:
     glob "^7.1.6"
     picomatch "^2.2.1"
 
-math-input-web-support@0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/math-input-web-support/-/math-input-web-support-0.2.4.tgz#92951836658ebb69b4fa120284393d55edf5d8f2"
-  integrity sha512-SYbD0HvkYffZ8fDib5Q0y7aQi4XOph/sOQEU5PdnkHDhWG2mYu/HFhhZTatuD/LCI3hJrgq+ZDxkIx6cb68X9A==
+math-input-web-support@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/math-input-web-support/-/math-input-web-support-0.2.5.tgz#78be3dc422587006eda28d56e78909c617bedf9d"
+  integrity sha512-nAmM8A2KlPEwve6TMOZKITYpEySZzMyOtc9sdbVNwwM/1vkCcM/e9tpjlLXgeMlLPtk37+4FqZeG2Wa6KyP1dw==
   dependencies:
     aphrodite "^0.2.0"
     create-react-class "^15.7.0"


### PR DESCRIPTION
### Issues

- When in editing mode, the user can see and edit both the `MathInput` ("friendly math") and the textarea with latex language, we want the user to see and edit just the `MathInput`
- When entering editing mode, the `MathInput` is not focused

### Solutions
- Removes the textarea with latex language
- Focus the `MathInput` when entering editing mode
  - It was necessary to [implement a `focus()` interface in the `math-input-web-support`](https://github.com/zonetti/math-input/commit/b6c0107dd6a255354c1adcc99f702682ee6bd63d) module.