### PR TITLE
Fix: Fix "Concluir edição" and "Remover" buttons styling

### DIFF
--- a/packages/katex/src/components/KatexBlock.tsx
+++ b/packages/katex/src/components/KatexBlock.tsx
@@ -86,11 +86,19 @@ const KatexBlock = (props: Props): JSX.Element => {
   if (data.isNew && !isEditing) startEdit();
 
   const buttonStyle: React.CSSProperties = {
+    width: 74,
+    height: 30,
     border: '1px solid #f1f1f1',
     borderRadius: '2px',
-    padding: '5px 10px',
+    padding: '7px 9px',
     background: '#fff',
     margin: '0 3px',
+    fontStyle: 'normal',
+    fontWeight: 400,
+    fontSize: '13px',
+    lineHeight: '16px',
+    color: '#111112',
+    cursor: 'pointer',
   };
 
   useEffect(() => {
@@ -98,15 +106,24 @@ const KatexBlock = (props: Props): JSX.Element => {
     mathInput.current.focus();
   }, [isEditing]);
 
+  const isDisabled = isInvalidTex || value.trim() === '';
+  const isInvalid = isInvalidTex && !(value.trim() === '');
+
   const editingForm = (
     <div className="GeekieKatex-EditPanel">
       <div className="GeekieKatex-EditPanel-Buttons">
         <button
-          style={buttonStyle}
-          disabled={isInvalidTex || value.trim() === ''}
+          style={{
+            ...buttonStyle,
+            width: isInvalid ? 'auto' : 74,
+            color: isDisabled ? '#A9A8A8' : '#111112',
+            backgroundColor: isDisabled ? '#EBE9E9' : 'transparent',
+            pointerEvents: isDisabled ? 'none' : 'all',
+          }}
+          disabled={isDisabled}
           onClick={save}
         >
-          {isInvalidTex ? 'Sintaxe inválida' : 'Concluir edição'}
+          {isInvalid ? 'Sintaxe inválida' : 'Salvar'}
         </button>
         <button style={buttonStyle} onClick={remove}>
           Remover


### PR DESCRIPTION
Esse PR corrige os estilos dos botões do plugin, e altera o texto do botão "Concluir edição" para "Salvar".

Como ficou:
![1](https://user-images.githubusercontent.com/29842092/190173218-bb3f3dc7-80ec-432f-95d2-99681b1e9478.png)
![2](https://user-images.githubusercontent.com/29842092/190173222-6d77d3d8-87c0-46a0-a9eb-dafe8ca58f0c.png)
![3](https://user-images.githubusercontent.com/29842092/190173226-36dd681b-b5aa-44e7-bae4-d519fee5bc81.png)
