### PR TITLE
Adiciona margem ao editar fórmula

### DIFF
--- a/packages/katex/src/components/KatexBlock.tsx
+++ b/packages/katex/src/components/KatexBlock.tsx
@@ -99,6 +99,7 @@ const KatexBlock = (props: Props): JSX.Element => {
     lineHeight: '16px',
     color: '#111112',
     cursor: 'pointer',
+    marginBottom: 100,
   };
 
   useEffect(() => {

--- a/packages/katex/src/components/KatexBlock.tsx
+++ b/packages/katex/src/components/KatexBlock.tsx
@@ -99,7 +99,7 @@ const KatexBlock = (props: Props): JSX.Element => {
     lineHeight: '16px',
     color: '#111112',
     cursor: 'pointer',
-    marginBottom: 100,
+    marginBottom: 160,
   };
 
   useEffect(() => {


### PR DESCRIPTION
O menu de editar fórmula podia ficar por cima da fórmula em si. Neste PR é esperado que seja adicionado 160px abaixo do botão para que o menu de editar fórmula não fique por cima da fórmula.

Como fica ao adicionar uma fórmula lá embaixo:
<img width="713" alt="image" src="https://user-images.githubusercontent.com/18106598/190413994-2f6643dc-9aac-49ff-9b11-055c1dba0b96.png">
