### PR TITLE
adds callback capability when inserting katex blocks

### DIFF
--- a/packages/katex/package.json
+++ b/packages/katex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geekie/geekie-katex",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/katex/src/components/KatexBlock.tsx
+++ b/packages/katex/src/components/KatexBlock.tsx
@@ -3,6 +3,7 @@ import katex from 'katex';
 import MathInput from 'math-input-web-support/dist/components/app';
 import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import KatexOutput from './KatexOutput';
+import { getInsertKatexCallback } from '../register';
 import { defaultTheme } from '../theme';
 
 type KatexInternals = typeof katex & {
@@ -74,6 +75,8 @@ const KatexBlock = (props: Props): JSX.Element => {
   };
 
   const save = (): void => {
+    const insertCallback = getInsertKatexCallback();
+    if (data.isNew && insertCallback) insertCallback();
     const entityKey = block.getEntityAt(0);
     const editorState = getEditorState();
     editorState

--- a/packages/katex/src/index.tsx
+++ b/packages/katex/src/index.tsx
@@ -6,7 +6,7 @@ import control from './control';
 import { KATEX_ENTITY } from './entity';
 import removeKatexBlock from './modifiers/removeKatexBlock';
 
-export { registerKatexCallback } from './register';
+export { registerInsertKatexCallback } from './register';
 
 type DraftStateMethods = {
   getEditorState: () => EditorState;

--- a/packages/katex/src/index.tsx
+++ b/packages/katex/src/index.tsx
@@ -6,6 +6,8 @@ import control from './control';
 import { KATEX_ENTITY } from './entity';
 import removeKatexBlock from './modifiers/removeKatexBlock';
 
+export { registerKatexCallback } from './register';
+
 type DraftStateMethods = {
   getEditorState: () => EditorState;
   setEditorState: (newEditorState: EditorState) => void;

--- a/packages/katex/src/register.ts
+++ b/packages/katex/src/register.ts
@@ -1,0 +1,16 @@
+type InsertKatexCallback = (() => void) | null;
+
+let insertKatexCallback: InsertKatexCallback = null;
+
+export const getInsertKatexCallback: () => InsertKatexCallback = () =>
+  insertKatexCallback;
+
+export const registerKatexCallback: (
+  newCallback: InsertKatexCallback
+) => void = (newCallback) => {
+  if (typeof newCallback !== 'function') {
+    throw Error('should pass a valid InsertKatexCallback');
+  } else {
+    insertKatexCallback = newCallback;
+  }
+};

--- a/packages/katex/src/register.ts
+++ b/packages/katex/src/register.ts
@@ -5,7 +5,7 @@ let insertKatexCallback: InsertKatexCallback = null;
 export const getInsertKatexCallback: () => InsertKatexCallback = () =>
   insertKatexCallback;
 
-export const registerKatexCallback: (
+export const registerInsertKatexCallback: (
   newCallback: InsertKatexCallback
 ) => void = (newCallback) => {
   if (typeof newCallback !== 'function') {

--- a/stories/katex/src/Katex.stories.tsx
+++ b/stories/katex/src/Katex.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { DraftailEditor } from 'draftail';
 import createKatexPlugin, {
-  registerKatexCallback,
+  registerInsertKatexCallback,
 } from '../../../packages/katex/src';
 
 export default {
@@ -12,7 +12,7 @@ export default {
 
 const katexPlugin = createKatexPlugin();
 
-registerKatexCallback(() => {
+registerInsertKatexCallback(() => {
   // eslint-disable-next-line no-console
   console.log('new katex added');
 });

--- a/stories/katex/src/Katex.stories.tsx
+++ b/stories/katex/src/Katex.stories.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { DraftailEditor } from "draftail";
-import createKatexPlugin from "../../../packages/katex/src";
+import { DraftailEditor } from 'draftail';
+import createKatexPlugin, {
+  registerKatexCallback,
+} from '../../../packages/katex/src';
 
 export default {
   title: 'Katex/Katex plugin',
@@ -10,10 +12,15 @@ export default {
 
 const katexPlugin = createKatexPlugin();
 
+registerKatexCallback(() => {
+  // eslint-disable-next-line no-console
+  console.log('new katex added');
+});
+
 export const Default: Story = () => (
   <DraftailEditor
     entityTypes={[katexPlugin.entityType]}
     controls={[katexPlugin.control]}
-    plugins={[katexPlugin]} 
+    plugins={[katexPlugin]}
   />
 );


### PR DESCRIPTION
### Issue

We want to be able to subscribe to the event of new katex blocks being added to the editor.

### Solution

Exports a `registerInsertKatexCallback` that allows the developer to implement a callback.

### How to test

In the `Katex/Katex plugin` storybook, check if the registered callback (`console.log`) is being called whenever a new katex block is added to the editor.