### PR TITLE
feat: adds callback capability for the event of changing the math input width

### DIFF
--- a/packages/katex/package.json
+++ b/packages/katex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geekie/geekie-katex",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/katex/src/components/KatexBlock.tsx
+++ b/packages/katex/src/components/KatexBlock.tsx
@@ -9,7 +9,7 @@ import React, {
   useState,
 } from 'react';
 import KatexOutput from './KatexOutput';
-import { getInsertKatexCallback } from '../register';
+import { getInsertKatexCallback, getMathInputWidthCallback } from '../register';
 import { defaultTheme } from '../theme';
 
 type KatexInternals = typeof katex & {
@@ -50,6 +50,7 @@ const KatexBlock = (props: Props): JSX.Element => {
   const [isInvalidTex, setIsInvalidTex] = useState(data.isInvalidTex);
   const [value, setValue] = useState(data.value);
   const mathInput = useRef<{ focus: () => void }>(null);
+  const inputSize = useRef<HTMLDivElement>(null);
 
   const callbacks: { [key: string]: () => void } = {};
 
@@ -126,6 +127,14 @@ const KatexBlock = (props: Props): JSX.Element => {
     mathInput.current.focus();
   }, [isEditing]);
 
+  useEffect(() => {
+    if (!inputSize.current) return;
+    const mathInputWidthCallback = getMathInputWidthCallback();
+    if (!mathInputWidthCallback) return;
+    const widthWithoutMargins = inputSize.current.clientWidth - 40;
+    mathInputWidthCallback(widthWithoutMargins);
+  }, [value]);
+
   const isDisabled = isInvalidTex || value.trim() === '';
   const isInvalid = isInvalidTex && !(value.trim() === '');
 
@@ -158,15 +167,21 @@ const KatexBlock = (props: Props): JSX.Element => {
     </div>
   );
 
+  const inputSizeStyle: React.CSSProperties = {
+    display: 'inline-block',
+  };
+
   const display = isEditing ? (
-    <MathInput
-      classname={`${defaultTheme.styleGlobal}`}
-      callbacks={callbacks}
-      katex={katex}
-      onChange={onValueChange}
-      value={value}
-      ref={mathInput}
-    />
+    <div ref={inputSize} style={inputSizeStyle}>
+      <MathInput
+        classname={`${defaultTheme.styleGlobal}`}
+        callbacks={callbacks}
+        katex={katex}
+        onChange={onValueChange}
+        value={value}
+        ref={mathInput}
+      />
+    </div>
   ) : (
     <KatexOutput onClick={startEdit} value={value} />
   );

--- a/packages/katex/src/index.tsx
+++ b/packages/katex/src/index.tsx
@@ -7,7 +7,10 @@ import control from './control';
 import { KATEX_ENTITY } from './entity';
 import removeKatexBlock from './modifiers/removeKatexBlock';
 
-export { registerInsertKatexCallback } from './register';
+export {
+  registerInsertKatexCallback,
+  registerMathInputWidthCallback,
+} from './register';
 
 type DraftStateMethods = {
   getEditorState: () => EditorState;

--- a/packages/katex/src/register.ts
+++ b/packages/katex/src/register.ts
@@ -14,3 +14,20 @@ export const registerInsertKatexCallback: (
     insertKatexCallback = newCallback;
   }
 };
+
+type MathInputWidthCallback = ((width: number) => void) | null;
+
+let mathInputWidthCallback: MathInputWidthCallback = null;
+
+export const getMathInputWidthCallback: () => MathInputWidthCallback = () =>
+  mathInputWidthCallback;
+
+export const registerMathInputWidthCallback: (
+  newCallback: MathInputWidthCallback
+) => void = (newCallback) => {
+  if (typeof newCallback !== 'function') {
+    throw Error('should pass a valid MathInputWidthCallback');
+  } else {
+    mathInputWidthCallback = newCallback;
+  }
+};

--- a/stories/katex/src/Katex.stories.tsx
+++ b/stories/katex/src/Katex.stories.tsx
@@ -3,6 +3,7 @@ import { Story, Meta } from '@storybook/react';
 import { DraftailEditor } from 'draftail';
 import createKatexPlugin, {
   registerInsertKatexCallback,
+  registerMathInputWidthCallback,
 } from '../../../packages/katex/src';
 
 export default {
@@ -24,6 +25,11 @@ const katexPlugin = createKatexPlugin({ infoComponent: tip });
 registerInsertKatexCallback(() => {
   // eslint-disable-next-line no-console
   console.log('new katex added');
+});
+
+registerMathInputWidthCallback((width) => {
+  // eslint-disable-next-line no-console
+  console.log('math input width:', width);
 });
 
 export const Default: Story = () => (


### PR DESCRIPTION
### Issue

We want to be able to subscribe to the event of changing the math input width.

### Solution

Exports `registerMathInputWidthCallback` in the Katex Plugin to enable registering a callback.

### How to test

Check the Katex Plugin Storybook and assert that the registered callback is called when the math input width changes.