### PR TITLE
feat: adds rules to change style

### DIFF
--- a/packages/katex/package.json
+++ b/packages/katex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geekie/geekie-katex",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/katex/src/components/KatexBlock.tsx
+++ b/packages/katex/src/components/KatexBlock.tsx
@@ -148,15 +148,11 @@ const KatexBlock = (props: Props): JSX.Element => {
     const triggeredRule = rulesSorted.filter(
       (r) => widthWithoutMargins > r.minWidth
     )[0];
-    if (triggeredRule) {
-      setTipText(() => triggeredRule.tipText);
-      setTipColor(() => triggeredRule.tipColor);
-      setDisableButton(() => triggeredRule.disableButton);
-    } else {
-      setTipText(() => undefined);
-      setTipColor(() => undefined);
-      setDisableButton(() => undefined);
-    }
+    setTipText(() => (triggeredRule ? triggeredRule.tipText : undefined));
+    setTipColor(() => (triggeredRule ? triggeredRule.tipColor : undefined));
+    setDisableButton(() =>
+      triggeredRule ? triggeredRule.disableButton : undefined
+    );
   }, [value]);
 
   const isDisabled = isInvalidTex || disableButton || value.trim() === '';

--- a/packages/katex/src/components/KatexBlock.tsx
+++ b/packages/katex/src/components/KatexBlock.tsx
@@ -1,27 +1,33 @@
 import { ContentBlock, EditorState } from 'draft-js';
 import katex from 'katex';
 import MathInput from 'math-input-web-support/dist/components/app';
-import React, {
-  ChangeEvent,
-  ReactElement,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import KatexOutput from './KatexOutput';
-import { getInsertKatexCallback, getMathInputWidthCallback } from '../register';
+import { getInsertKatexCallback } from '../register';
 import { defaultTheme } from '../theme';
 
 type KatexInternals = typeof katex & {
   __parse: (s: string) => void;
 };
 
+type RGB = `rgb(${number}, ${number}, ${number})`;
+type RGBA = `rgba(${number}, ${number}, ${number}, ${number})`;
+type HEX = `#${string}`;
+type Color = RGB | RGBA | HEX | string;
+
+export type Rule = {
+  minWidth: number;
+  tipText?: string;
+  tipColor?: Color;
+  disableButton?: true;
+};
+
 export type KateBlockProps = {
   getEditorState: () => EditorState;
-  infoComponent?: ReactElement;
   onRemove: (key: string) => void;
   onStartEdit: (key: string) => void;
   onFinishEdit: (key: string, newEditorState: EditorState) => void;
+  rules?: Rule[];
 };
 
 export type KatexBlockState = {
@@ -38,7 +44,7 @@ type Props = {
 
 const KatexBlock = (props: Props): JSX.Element => {
   const { block, blockProps } = props;
-  const { getEditorState, infoComponent, onRemove, onStartEdit, onFinishEdit } =
+  const { getEditorState, rules, onRemove, onStartEdit, onFinishEdit } =
     blockProps;
 
   const data: KatexBlockState = getEditorState()
@@ -49,10 +55,19 @@ const KatexBlock = (props: Props): JSX.Element => {
   const [isEditing, setIsEditing] = useState(data.isEditing);
   const [isInvalidTex, setIsInvalidTex] = useState(data.isInvalidTex);
   const [value, setValue] = useState(data.value);
+  const [tipColor, setTipColor] = useState<Color | undefined>();
+  const [tipText, setTipText] = useState<string | undefined>();
+  const [disableButton, setDisableButton] = useState<true | undefined>();
   const mathInput = useRef<{ focus: () => void }>(null);
   const inputSize = useRef<HTMLDivElement>(null);
 
   const callbacks: { [key: string]: () => void } = {};
+
+  let rulesSorted: Rule[] | undefined;
+  if (rules && rules.length) {
+    rulesSorted = [...rules];
+    rulesSorted.sort((r1, r2) => r2.minWidth - r1.minWidth);
+  }
 
   const onValueChange = (
     evt: ChangeEvent<HTMLTextAreaElement> | string
@@ -128,15 +143,27 @@ const KatexBlock = (props: Props): JSX.Element => {
   }, [isEditing]);
 
   useEffect(() => {
-    if (!inputSize.current) return;
-    const mathInputWidthCallback = getMathInputWidthCallback();
-    if (!mathInputWidthCallback) return;
+    if (!inputSize.current || !rulesSorted) return;
     const widthWithoutMargins = inputSize.current.clientWidth - 40;
-    mathInputWidthCallback(widthWithoutMargins);
+    const triggeredRule = rulesSorted.filter(
+      (r) => widthWithoutMargins > r.minWidth
+    )[0];
+    if (triggeredRule) {
+      setTipText(() => triggeredRule.tipText);
+      setTipColor(() => triggeredRule.tipColor);
+      setDisableButton(() => triggeredRule.disableButton);
+    } else {
+      setTipText(() => undefined);
+      setTipColor(() => undefined);
+      setDisableButton(() => undefined);
+    }
   }, [value]);
 
-  const isDisabled = isInvalidTex || value.trim() === '';
+  const isDisabled = isInvalidTex || disableButton || value.trim() === '';
   const isInvalid = isInvalidTex && !(value.trim() === '');
+
+  const tipStyle = tipColor ? { color: tipColor } : {};
+  const tip = tipText && <p style={tipStyle}>{tipText}</p>;
 
   const editingForm = (
     <div className="GeekieKatex-EditPanel">
@@ -144,7 +171,7 @@ const KatexBlock = (props: Props): JSX.Element => {
         className="GeekieKatex-InfoComponent-Container"
         style={infoComponentStyle}
       >
-        {infoComponent}
+        {tip}
       </div>
       <div className="GeekieKatex-EditPanel-Buttons">
         <button

--- a/packages/katex/src/index.tsx
+++ b/packages/katex/src/index.tsx
@@ -1,16 +1,12 @@
 import { ContentBlock, EditorState } from 'draft-js';
 import 'katex/dist/katex.min.css';
 import 'mathquill-commonjs/mathquill.css';
-import { ReactElement } from 'react';
-import KatexBlock, { KateBlockProps } from './components/KatexBlock';
+import KatexBlock, { KateBlockProps, Rule } from './components/KatexBlock';
 import control from './control';
 import { KATEX_ENTITY } from './entity';
 import removeKatexBlock from './modifiers/removeKatexBlock';
 
-export {
-  registerInsertKatexCallback,
-  registerMathInputWidthCallback,
-} from './register';
+export { registerInsertKatexCallback } from './register';
 
 type DraftStateMethods = {
   getEditorState: () => EditorState;
@@ -34,12 +30,12 @@ type KatexPlugin = {
 };
 
 type KatexPluginProps = {
-  infoComponent?: ReactElement;
+  rules?: Rule[];
 };
 
 export default (props?: KatexPluginProps): KatexPlugin => {
   const blocksInEditingMode = new Map();
-  const infoComponent = props?.infoComponent;
+  const rules = props?.rules;
 
   return {
     blockRendererFn: (
@@ -58,7 +54,7 @@ export default (props?: KatexPluginProps): KatexPlugin => {
         editable: false,
         props: {
           getEditorState,
-          infoComponent,
+          rules,
 
           onStartEdit: (blockKey: string) => {
             setReadOnly(true);

--- a/packages/katex/src/register.ts
+++ b/packages/katex/src/register.ts
@@ -14,20 +14,3 @@ export const registerInsertKatexCallback: (
     insertKatexCallback = newCallback;
   }
 };
-
-type MathInputWidthCallback = ((width: number) => void) | null;
-
-let mathInputWidthCallback: MathInputWidthCallback = null;
-
-export const getMathInputWidthCallback: () => MathInputWidthCallback = () =>
-  mathInputWidthCallback;
-
-export const registerMathInputWidthCallback: (
-  newCallback: MathInputWidthCallback
-) => void = (newCallback) => {
-  if (typeof newCallback !== 'function') {
-    throw Error('should pass a valid MathInputWidthCallback');
-  } else {
-    mathInputWidthCallback = newCallback;
-  }
-};

--- a/stories/katex/src/Katex.stories.tsx
+++ b/stories/katex/src/Katex.stories.tsx
@@ -3,7 +3,6 @@ import { Story, Meta } from '@storybook/react';
 import { DraftailEditor } from 'draftail';
 import createKatexPlugin, {
   registerInsertKatexCallback,
-  registerMathInputWidthCallback,
 } from '../../../packages/katex/src';
 
 export default {
@@ -11,25 +10,17 @@ export default {
   component: DraftailEditor,
 } as Meta;
 
-const tip = (
-  <div>
-    <p style={{ margin: 0 }}>
-      <b style={{ color: 'orange' }}>Dica:</b> Esse plugin aceita um componente
-      externo de informações
-    </p>
-  </div>
-);
-
-const katexPlugin = createKatexPlugin({ infoComponent: tip });
+const katexPlugin = createKatexPlugin({
+  rules: [
+    { minWidth: 100, tipText: 'Dica: green', tipColor: 'green' },
+    { minWidth: 150, tipText: 'Dica: blue', tipColor: 'blue' },
+    { minWidth: 200, disableButton: true },
+  ],
+});
 
 registerInsertKatexCallback(() => {
   // eslint-disable-next-line no-console
   console.log('new katex added');
-});
-
-registerMathInputWidthCallback((width) => {
-  // eslint-disable-next-line no-console
-  console.log('math input width:', width);
 });
 
 export const Default: Story = () => (


### PR DESCRIPTION
### Issue

We want to be able to change style and the save button status based on the math-input's width.

### Solution

Adds optional rules that can be used to change style based on the math-input's width.

### How to test

Katex Storybook.